### PR TITLE
Set up Codecov (#56)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,14 +21,10 @@ jobs:
           pip install .
           pip install -r requirements.txt
           pip install pytest
+          pip install pytest-cov
 
-      - name: Run pytest
-        run: pytest devolearn/tests/test.py
-
-      - name: Generate Report
-        run: |
-          pip install coverage
-          coverage run -m pytest devolearn/tests/test.py
+      - name: Run tests
+        run: pytest devolearn/tests/test.py --cov=devolearn --cov-report=xml
 
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,4 +24,13 @@ jobs:
 
       - name: Run pytest
         run: pytest devolearn/tests/test.py
-     
+
+      - name: Generate Report
+        run: |
+          pip install coverage
+          coverage run -m pytest devolearn/tests/test.py
+
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,4 @@ torchvision>=0.8.1
 tqdm==4.56.0
 typing-extensions==3.7.4.3
 wget==3.2
-coverage
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ torchvision>=0.8.1
 tqdm==4.56.0
 typing-extensions==3.7.4.3
 wget==3.2
+coverage


### PR DESCRIPTION
#56 
Is this okay? 

This repo first needs to be linked to [Codecov.io](https://about.codecov.io/) choosing it from the list of repos and generating a token.

Also, we can add coverage reports right in the GitHub pull requests by adding a `codecov.yml` file in the root of the project. 

Like: 
![Screenshot from 2021-09-14 16-04-45](https://user-images.githubusercontent.com/73424897/133243697-f549b23b-7d9f-4426-9de8-bbc0d150be9f.png)


Should that be done too?