### PR TITLE
Fix test fail: Due to recompute_scale_factor missing in UpsamplingBilinear2d

### DIFF
--- a/devolearn/cell_membrane_segmentor/cell_membrane_segmentor.py
+++ b/devolearn/cell_membrane_segmentor/cell_membrane_segmentor.py
@@ -138,6 +138,8 @@ class cell_membrane_segmentor(InferenceEngine):
         im = cv2.imread(image_path,0)
 
         tensor = self.preprocess(im)
+
+        self.model.segmentation_head[1].recompute_scale_factor = None
         res = self.model(tensor).detach().cpu().numpy()[0][0]
         
         res = cv2.resize(res,pred_size)

--- a/devolearn/cell_membrane_segmentor/cell_membrane_segmentor.py
+++ b/devolearn/cell_membrane_segmentor/cell_membrane_segmentor.py
@@ -139,6 +139,9 @@ class cell_membrane_segmentor(InferenceEngine):
 
         tensor = self.preprocess(im)
 
+        # The model has issues with the latest PyTorch versions, which causes
+        # AttributeError: 'Upsample' object has no attribute 'recompute_scale_factor'
+        # To avoid this, we manually set the recompute_scale_factor attribute to None
         self.model.segmentation_head[1].recompute_scale_factor = None
         res = self.model(tensor).detach().cpu().numpy()[0][0]
         

--- a/devolearn/cell_nucleus_segmentor/cell_nucleus_segmentor.py
+++ b/devolearn/cell_nucleus_segmentor/cell_nucleus_segmentor.py
@@ -98,7 +98,12 @@ class cell_nucleus_segmentor(InferenceEngine):
 
         im = cv2.imread(image_path,0)
         tensor = self.preprocess(im)
+
+        # The model has issues with the latest PyTorch versions, which causes
+        # AttributeError: 'Upsample' object has no attribute 'recompute_scale_factor'
+        # To avoid this, we manually set the recompute_scale_factor attribute to None
         self.model.segmentation_head[1].recompute_scale_factor = None
+        
         res = self.model(tensor).detach().cpu().numpy()[0][0]
         res = cv2.resize(res,pred_size)
         return res

--- a/devolearn/cell_nucleus_segmentor/cell_nucleus_segmentor.py
+++ b/devolearn/cell_nucleus_segmentor/cell_nucleus_segmentor.py
@@ -98,6 +98,7 @@ class cell_nucleus_segmentor(InferenceEngine):
 
         im = cv2.imread(image_path,0)
         tensor = self.preprocess(im)
+        self.model.segmentation_head[1].recompute_scale_factor = None
         res = self.model(tensor).detach().cpu().numpy()[0][0]
         res = cv2.resize(res,pred_size)
         return res


### PR DESCRIPTION
There are issues in using UpsamplingBilinear2d for torch version >= 1.9.0 [[ref](https://github.com/ultralytics/yolov5/issues/6948)]

One possible solution is to edit `..site-packages\torch\nn\modules`:
```
def forward(self, input: Tensor) -> Tensor:
    return F.interpolate(input, self.size, self.scale_factor, self.mode, self.align_corners,
                         #recompute_scale_factor=self.recompute_scale_factor
                         )
```

But this isn't possible in this case. So this PR is to manually set `recompute_scale_factor`.