### PR TITLE
Colab upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ devolearn.egg-info/
 dist/
 centroids.csv
 .vscode/
+.venv/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Contents
 
-* [Example notebooks](README.md#example-notebooks)
+* [Example notebooks](https://github.com/DevoLearn/devolearn#example-notebooks)
 * [Segmenting the C. elegans embryo](https://github.com/DevoLearn/devolearn#segmenting-the-c-elegans-embryo)
 * [Generating synthetic images of embryos with a GAN](https://github.com/DevoLearn/devolearn#generating-synthetic-images-of-embryos-with-a-pre-trained-gan)
 * [Predicting populations of cells within the C. elegans embryo](https://github.com/DevoLearn/devolearn#predicting-populations-of-cells-within-the-c-elegans-embryo)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Contents
 
-* [Example notebooks](https://github.com/DevoLearn/devolearn#example-notebooks)
+* [Example notebooks](README.md#example-notebooks)
 * [Segmenting the C. elegans embryo](https://github.com/DevoLearn/devolearn#segmenting-the-c-elegans-embryo)
 * [Generating synthetic images of embryos with a GAN](https://github.com/DevoLearn/devolearn#generating-synthetic-images-of-embryos-with-a-pre-trained-gan)
 * [Predicting populations of cells within the C. elegans embryo](https://github.com/DevoLearn/devolearn#predicting-populations-of-cells-within-the-c-elegans-embryo)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ kiwisolver==1.3.1
 matplotlib
 munch==2.5.0
 networkx==2.5
-numpy==1.19.5
+numpy>=1.19.5
 opencv-python==4.5.1.48
 pandas==1.1.5
 Pillow
@@ -32,6 +32,6 @@ timm==0.3.2
 torch>=1.7.0
 torchvision>=0.8.1
 tqdm==4.56.0
-typing-extensions==3.7.4.3
+typing-extensions>=3.7.4.3
 wget==3.2
 pytest-cov


### PR DESCRIPTION
Leaving numpy and typing-extensions to not change when torch goes to a higher version (for example torch 1.12 installs numpy 1.23).
Tests run OK!
Checked with torch  1.12.1+cu116

Adding ignoring venv folder files.

Warnings:
.venv/lib/python3.9/site-packages/torchvision/transforms/transforms.py:332: UserWarning: Argument 'interpolation' of type int is deprecated since 0.13 and will be removed in 0.15. Please use InterpolationMode enum.

venv/lib/python3.9/site-packages/sklearn/base.py:310: UserWarning: Trying to unpickle estimator MinMaxScaler from version 0.24.1 when using version 0.24.0. This might lead to breaking code or invalid results. Use at your own risk.


